### PR TITLE
fix: prevent past date validation on update & add swagger documentation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>dotenv-java</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/monsterquest/backend/config/OpenAPIConfig.java
+++ b/backend/src/main/java/com/monsterquest/backend/config/OpenAPIConfig.java
@@ -1,0 +1,18 @@
+package com.monsterquest.backend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("MonsterQuest API")
+                        .version("1.0")
+                        .description("Das Backend-System für das Quest- und Gamification-Management von MonsterQuest. Erlaubt das Erstellen, Verfolgen und Archivieren von Aufgaben."));
+    }
+}

--- a/backend/src/main/java/com/monsterquest/backend/controller/QuestController.java
+++ b/backend/src/main/java/com/monsterquest/backend/controller/QuestController.java
@@ -1,5 +1,7 @@
 package com.monsterquest.backend.controller;
 
+import com.monsterquest.backend.dto.QuestCreateRequest;
+import com.monsterquest.backend.dto.QuestUpdateRequest;
 import com.monsterquest.backend.entity.Quest;
 import com.monsterquest.backend.service.QuestService;
 import jakarta.validation.Valid;
@@ -7,44 +9,59 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
 import java.util.List;
 
 @CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/quests") // Alle Anfragen an /api/quests landen hier
 @RequiredArgsConstructor
+@Tag(name = "1. Quest-Verwaltung", description = "Endpoints für den Lebenszyklus von Quests (Erstellen, Bearbeiten, Löschen)")
 public class QuestController {
 
     private final QuestService questService;
 
     @GetMapping
+    @Operation(summary = "Alle Quests abrufen", description = "Liefert eine komplette Liste aller in der Datenbank existierenden Quests (aktiv und archiviert).")
     public List<Quest> getAll() {
         return questService.getAllQuests();
     }
 
     @GetMapping("/active")
+    @Operation(summary = "Aktive Quests filtern", description = "Liefert alle Quests, die noch offen sind UND deren harte Deadline noch nicht abgelaufen ist.")
     public List<Quest> getActive() {
         return questService.getActiveQuests();
     }
 
     @GetMapping("/archive")
+    @Operation(summary = "Archivierte Quests filtern", description = "Liefert alle erledigten Quests sowie die Quests, die aufgrund einer harten Deadline abgelaufen sind.")
     public List<Quest> getArchive() {
         return questService.getArchivedQuests();
     }
 
     @PostMapping
-    public Quest create(@Valid @RequestBody Quest quest) {
-        return questService.createQuest(quest);
+    @Operation(summary = "Neue Quest erstellen", description = "Erstellt eine neue Quest. Validiert, dass die Deadline (falls angegeben) in der Zukunft liegt.")
+    @ApiResponse(responseCode = "201", description = "Quest erfolgreich erstellt")
+    @ApiResponse(responseCode = "400", description = "Ungültige Eingabedaten (z. B. Titel zu kurz oder Datum in der Vergangenheit)")
+    public Quest create(@Valid @RequestBody QuestCreateRequest dto) {
+        return questService.createQuest(dto);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Quest> update(@PathVariable Long id, @Valid @RequestBody Quest quest) {
-        return questService.updateQuest(id, quest)
+    @Operation(summary = "Quest aktualisieren", description = "Aktualisiert eine bestehende Quest anhand ihrer ID. Erlaubt das Ändern des Status (completed) und ignoriert abgelaufene Deadlines.")
+    @ApiResponse(responseCode = "200", description = "Quest erfolgreich aktualisiert")
+    @ApiResponse(responseCode = "404", description = "Quest mit der angegebenen ID wurde nicht gefunden")
+    public ResponseEntity<Quest> update(@PathVariable Long id, @Valid @RequestBody QuestUpdateRequest dto) {
+        return questService.updateQuest(id, dto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "Quest löschen", description = "Löscht eine bestehende Quest anhand ihrer ID.")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         return questService.deleteQuest(id)
                 ? ResponseEntity.noContent().build()

--- a/backend/src/main/java/com/monsterquest/backend/dto/QuestBaseRequest.java
+++ b/backend/src/main/java/com/monsterquest/backend/dto/QuestBaseRequest.java
@@ -1,0 +1,43 @@
+package com.monsterquest.backend.dto;
+
+import com.monsterquest.backend.entity.Recurrence;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Data
+public class QuestBaseRequest {
+    @NotBlank(message = "Der Titel darf nicht leer sein")
+    @Size(min = 3, max = 50)
+    @Schema(description = "Der Titel der Aufgabe", example = "Drachen im Keller besiegen", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String title;
+
+    @Size(max = 500)
+    @Schema(description = "Optionale Details zur Quest", example = "Die Kellerdrachen klauen nachts immer die Socken aus der Waschmaschine.")
+    private String description;
+
+    @NotNull(message = "Schwierigkeit muss angegeben werden")
+    @Min(value = 1, message = "Die Schwierigkeit muss mindestens 1 sein")
+    @Max(value = 10, message = "Die Schwierigkeit darf maximal 10 sein")
+    @Schema(description = "Schwierigkeitsgrad der Quest von 1 (sehr leicht) bis 10 (episch)", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
+    private int difficulty;
+
+    @Schema(description = "Zeitpunkt, bis wann die Quest erledigt sein muss (ISO-Format)", example = "2026-12-31T23:59:59")
+    private LocalDateTime deadline;
+
+    @Schema(description = "Wenn true, gilt die Quest nach Ablauf der Deadline sofort als gescheitert", example = "false")
+    private boolean hardDeadline;
+
+    @Schema(description = "Wiederholungsintervall der Quest", example = "NONE")
+    private Recurrence recurrence;
+
+    @AssertTrue(message = "Ohne Datum sind harte Fristen oder Wiederholungen nicht erlaubt!")
+    public boolean isDeadlineLogicValid() {
+        if (deadline == null) {
+            return !hardDeadline && recurrence == Recurrence.NONE;
+        }
+        return true;
+    }
+}

--- a/backend/src/main/java/com/monsterquest/backend/dto/QuestCreateRequest.java
+++ b/backend/src/main/java/com/monsterquest/backend/dto/QuestCreateRequest.java
@@ -1,0 +1,19 @@
+package com.monsterquest.backend.dto;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Schema(description = "Datenmodell zum Erstellen einer neuen Quest. Die Deadline muss in der Zukunft liegen.")
+public class QuestCreateRequest extends QuestBaseRequest {
+    @FutureOrPresent(message = "Deadline muss in der Zukunft liegen")
+    @Override
+    public LocalDateTime getDeadline() {
+        return super.getDeadline();
+    }
+}

--- a/backend/src/main/java/com/monsterquest/backend/dto/QuestUpdateRequest.java
+++ b/backend/src/main/java/com/monsterquest/backend/dto/QuestUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.monsterquest.backend.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Schema(description = "Datenmodell zum Aktualisieren einer bestehenden Quest. Erlaubt die Änderung des Status.")
+public class QuestUpdateRequest extends QuestBaseRequest {
+    @Schema(description = "Gibt an, ob die Quest erfolgreich abgeschlossen wurde", example = "true")
+    private boolean completed; // Nur beim Update erlaubt/sinnvoll
+}

--- a/backend/src/main/java/com/monsterquest/backend/entity/Quest.java
+++ b/backend/src/main/java/com/monsterquest/backend/entity/Quest.java
@@ -1,9 +1,7 @@
 package com.monsterquest.backend.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
 import lombok.*;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -18,20 +16,14 @@ public class Quest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank(message = "Der Titel darf nicht leer sein")
-    @Size(min = 3, max = 50)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String title;
 
-    @Size(max = 500)
-    private String description; // Optional (keine Annotation)
+    @Column(length = 500)
+    private String description; // Optional
 
-    @NotNull(message = "Schwierigkeit muss angegeben werden")
-    @Min(value = 1, message = "Die Schwierigkeit muss mindestens 1 sein")
-    @Max(value = 10, message = "Die Schwierigkeit darf maximal 10 sein")
     private int difficulty;
 
-    @FutureOrPresent(message = "Deadline muss in der Zukunft liegen")
     private LocalDateTime deadline; // Optional
 
     private boolean hardDeadline = false;
@@ -40,16 +32,6 @@ public class Quest {
     private Recurrence recurrence = Recurrence.NONE;
 
     private boolean completed = false;
-
-    @AssertTrue(message = "Ohne Datum sind harte Fristen oder Wiederholungen nicht erlaubt!")
-    @SuppressWarnings("unused")
-    public boolean isDeadlineLogicValid() {
-        if (deadline == null) {
-            // Wenn kein Datum da ist, MÜSSEN diese false/NONE sein
-            return !hardDeadline && recurrence == Recurrence.NONE;
-        }
-        return true;
-    }
 
     @PrePersist
     @PreUpdate

--- a/backend/src/main/java/com/monsterquest/backend/service/QuestService.java
+++ b/backend/src/main/java/com/monsterquest/backend/service/QuestService.java
@@ -1,5 +1,7 @@
 package com.monsterquest.backend.service;
 
+import com.monsterquest.backend.dto.QuestCreateRequest;
+import com.monsterquest.backend.dto.QuestUpdateRequest;
 import com.monsterquest.backend.entity.Quest;
 import com.monsterquest.backend.repository.QuestRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,20 +27,30 @@ public class QuestService {
         return questRepository.findAllArchived();
     }
 
-    public Quest createQuest(Quest quest) {
+    public Quest createQuest(QuestCreateRequest dto) {
+        Quest quest = new Quest();
+        // Aus dem DTO in die Entity mappen
+        quest.setTitle(dto.getTitle());
+        quest.setDescription(dto.getDescription());
+        quest.setDifficulty(dto.getDifficulty());
+        quest.setDeadline(dto.getDeadline());
+        quest.setHardDeadline(dto.isHardDeadline());
+        quest.setRecurrence(dto.getRecurrence());
+        quest.setCompleted(false);
+
         return questRepository.save(quest);
     }
 
-    public Optional<Quest> updateQuest(Long id, Quest details) {
+    public Optional<Quest> updateQuest(Long id, QuestUpdateRequest dto) {
         return questRepository.findById(id).map(quest -> {
-            // Mapping der Felder
-            quest.setTitle(details.getTitle());
-            quest.setDescription(details.getDescription());
-            quest.setDifficulty(details.getDifficulty());
-            quest.setDeadline(details.getDeadline());
-            quest.setHardDeadline(details.isHardDeadline());
-            quest.setRecurrence(details.getRecurrence());
-            quest.setCompleted(details.isCompleted());
+            quest.setTitle(dto.getTitle());
+            quest.setDescription(dto.getDescription());
+            quest.setDifficulty(dto.getDifficulty());
+            quest.setDeadline(dto.getDeadline());
+            quest.setHardDeadline(dto.isHardDeadline());
+            quest.setRecurrence(dto.getRecurrence());
+            quest.setCompleted(dto.isCompleted());
+
             return questRepository.save(quest);
         });
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.datasource.password=${DB_PASSWORD:geheim}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
+
+# Swagger
+springdoc.swagger-ui.operationsSorter=alpha

--- a/frontend/src/features/quests/QuestForm.tsx
+++ b/frontend/src/features/quests/QuestForm.tsx
@@ -49,19 +49,21 @@ export const QuestForm = ({ initialData, onSuccess, onDelete }: QuestFormProps) 
       return false;
     }
 
-    // 2. Deine Spezial-Logik (Abhängigkeiten)
+    // 2. Abhängigkeiten von Uhrzeit, Hard Deadline und Wiederholung
     if (!date && (time || hardDeadline || recurrence !== 'NONE')) {
       setError('Uhrzeit/Harte Deadline/Wiederholung geht nur mit einem Datum.');
       return false;
     }
 
-    // 3. Logik für Datum in der Vergangenheit
-    const selectedDate = new Date(date);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    if (selectedDate.getTime() < today.getTime()) {
-      setError('Das Datum darf nicht in der Vergangenheit liegen.');
-      return false;
+    // 3. Kein Datum in der Vergangenheit (nur bei Quest-Erstellung)
+    if (!initialData) {
+      const selectedDate = new Date(date);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      if (selectedDate.getTime() < today.getTime()) {
+        setError('Das Datum darf nicht in der Vergangenheit liegen.');
+        return false;
+      }
     }
 
     setError(null);


### PR DESCRIPTION
- Fixed bug where quests failed validation due to past deadlines on PUT requests
- Introduced Data Transfer Objects (DTOs) to separate API layer from database entities
- Integrated and configured Swagger/OpenAPI for interactive API documentation